### PR TITLE
Add bounding box to pad shape polarity object

### DIFF
--- a/API.md
+++ b/API.md
@@ -134,10 +134,10 @@ A special nested structure that takes an array `shape` of rectangles or polygons
 
 **layer polarity change**
 
-A modifier that changes the subsequent shape polarities to `clear` or `dark`. By default, all shapes are `dark`. A dark shape creates an image, while a clear shape erases any shape that lies below it. Used for macro-defined tools and standard tools with holes:
+A modifier that changes the subsequent shape polarities to `clear` or `dark`. By default, all shapes are `dark`. A dark shape creates an image, while a clear shape erases any shape that lies below it. Used for macro-defined tools and standard tools with holes. The polarity object also includes the current size of the image.
 
 ``` javascript
-{type: 'layer', polarity: 'clear' OR 'dark'}
+{type: 'layer', polarity: POLARITY, box: [X_MIN, Y_MIN, X_MAX, Y_MAX]}
 ```
 
 ### pad object

--- a/lib/_pad-shape.js
+++ b/lib/_pad-shape.js
@@ -5,6 +5,7 @@ var reduce = require('lodash.reduce')
 var transform = require('lodash.transform')
 var mapValues = require('lodash.mapvalues')
 var isFunction = require('lodash.isfunction')
+var clone = require('lodash.clone')
 
 var boundingBox = require('./_box')
 
@@ -240,7 +241,8 @@ var runMacro = function(mods, blocks) {
     if ((block.exp != null) && (block.exp !== exposure)) {
       result.shape.push({
         type: 'layer',
-        polarity: (block.exp === 1) ? 'dark' : 'clear'
+        polarity: (block.exp === 1) ? 'dark' : 'clear',
+        box: clone(result.box)
       })
       exposure = block.exp
     }
@@ -302,8 +304,11 @@ var runMacro = function(mods, blocks) {
         return true
     }
 
-    result.shape = result.shape.concat(shapeAndBox.shape),
-    result.box = boundingBox.add(result.box, shapeAndBox.box)
+    result.shape = result.shape.concat(shapeAndBox.shape)
+    // only change the box if the exposure is creating an image
+    if (exposure === 1) {
+      result.box = boundingBox.add(result.box, shapeAndBox.box)
+    }
   }, emptyMacro)
 }
 
@@ -349,7 +354,7 @@ var padShape = function(tool, macros) {
       circle(tool.hole[0]).shape :
       rect(tool.hole[0], tool.hole[1]).shape
 
-    shape.push({type: 'layer', polarity: 'clear'}, holeShape)
+    shape.push({type: 'layer', polarity: 'clear', box: box}, holeShape)
   }
 
   return {shape: shape, box: box}

--- a/lib/gerber-plotter.js
+++ b/lib/gerber-plotter.js
@@ -3,7 +3,7 @@
 
 var TransformStream = require('readable-stream').Transform
 var has = require('lodash.has')
-var mapValues = require('lodash.mapValues')
+var mapValues = require('lodash.mapvalues')
 
 var PathGraph = require('./path-graph')
 var applyOptions = require('./_apply-options')

--- a/test/gerber-plotter_test.js
+++ b/test/gerber-plotter_test.js
@@ -256,14 +256,14 @@ describe('gerber plotter', function() {
         p.write({cmd: 'tool', key: '11', val: circle1})
         expect(p._tool.pad).to.eql([
           {type: 'circle', cx: 0, cy: 0, r: 1},
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: [-1, -1, 1, 1]},
           {type: 'circle', cx: 0, cy: 0, r: 0.5}
         ])
 
         p.write({cmd: 'tool', key: '12', val: circle2})
         expect(p._tool.pad).to.eql([
           {type: 'circle', cx: 0, cy: 0, r: 1.5},
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: [-1.5, -1.5, 1.5, 1.5]},
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
         ])
       })
@@ -281,14 +281,14 @@ describe('gerber plotter', function() {
         p.write({cmd: 'tool', key: '11', val: rect1})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 3, height: 4},
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: [-1.5, -2, 1.5, 2]},
           {type: 'circle', cx: 0, cy: 0, r: 0.5}
         ])
 
         p.write({cmd: 'tool', key: '12', val: rect2})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 5, height: 6},
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: [-2.5, -3, 2.5, 3]},
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
         ])
       })
@@ -306,14 +306,14 @@ describe('gerber plotter', function() {
         p.write({cmd: 'tool', key: '11', val: obround1})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 1.5, width: 4, height: 3},
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: [-2, -1.5, 2, 1.5]},
           {type: 'circle', cx: 0, cy: 0, r: 0.5}
         ])
 
         p.write({cmd: 'tool', key: '12', val: obround2})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 2.5, width: 5, height: 6},
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: [-2.5, -3, 2.5, 3]},
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
         ])
       })
@@ -334,6 +334,8 @@ describe('gerber plotter', function() {
 
         p.write({cmd: 'tool', key: '11', val: poly1})
         var poly = p._tool.pad[0]
+        var box = [-0.96592583, -0.96592583, 0.96592583, 0.96592583]
+
         expect(p._tool.pad).to.have.length(3)
         expect(poly).to.have.all.keys(['type', 'points'])
         expect(poly.type).to.equal('poly')
@@ -344,14 +346,16 @@ describe('gerber plotter', function() {
           [-0.70710678, -0.70710678],
           [0.25881905, -0.96592583],
           [0.96592583, -0.25881905]
-        ], 10)
+        ])
         expect(p._tool.pad.slice(1)).to.eql([
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: box},
           {type: 'circle', cx: 0, cy: 0, r: 0.5}
         ])
 
         p.write({cmd: 'tool', key: '12', val: poly2})
         poly = p._tool.pad[0]
+        box = [-0.98480775, -0.98480775, 0.98480775, 0.98480775]
+
         expect(p._tool.pad).to.have.length(3)
         expect(poly).to.have.all.keys(['type', 'points'])
         expect(poly.type).to.equal('poly')
@@ -370,7 +374,7 @@ describe('gerber plotter', function() {
           [-0.34202014, 0.93969262]
         ])
         expect(p._tool.pad.slice(1)).to.eql([
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: box},
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
         ])
       })
@@ -877,10 +881,10 @@ describe('gerber plotter', function() {
         p.write(tool)
         expect(p._tool.pad).to.eql([
           {type: 'circle', cx: -2, cy: 0, r: 2},
-          {type: 'layer', polarity: 'clear'},
+          {type: 'layer', polarity: 'clear', box: [-4, -2, 0, 2]},
           {type: 'rect', width: 1, height: 1, cx: -1, cy: 0, r: 0},
           {type: 'rect', width: 1, height: 1, cx: 1, cy: 0, r: 0},
-          {type: 'layer', polarity: 'dark'},
+          {type: 'layer', polarity: 'dark', box: [-4, -2, 0, 2]},
           {type: 'circle', cx: 2, cy: 0, r: 2}
         ])
         expect(p._tool.box).to.eql([-4, -2, 4, 2])


### PR DESCRIPTION
This adjusts the layer polarity pad shape object to better match the overall image polarity object. The pad layer object now includes the size of the pad at the time of the polarity change to make mask generation easier for stream consumers.