### PR TITLE
Factor out lodash deps to reduce bundle size

### DIFF
--- a/lib/_operate.js
+++ b/lib/_operate.js
@@ -1,10 +1,6 @@
 // operate the plotter
 'use strict'
 
-var filter = require('lodash.filter')
-var reduce = require('lodash.reduce')
-var forEach = require('lodash.foreach')
-
 var boundingBox = require('./_box')
 
 var HALF_PI = Math.PI / 2
@@ -140,7 +136,7 @@ var arcBox = function(cenAndAngles, r, region, tool, dir) {
     points.push([center[0], center[1] - r])
   }
 
-  return reduce(points, function(result, m) {
+  return points.reduce(function(result, m) {
     if (!region) {
       var mBox = boundingBox.translate(tool.box, m)
       return boundingBox.add(result, mBox)
@@ -223,7 +219,7 @@ var drawArc = function(
     validCenters = arcCenterFromRadius(start, end, mode, epsilon, offset[2])
   }
   else if (arc === 's') {
-    validCenters = filter(candidates, function(c) {
+    validCenters = candidates.filter(function(c) {
       var startDist = Math.sqrt(Math.pow(c[0] - start[0], 2) + Math.pow(c[1] - start[1], 2))
       var endDist = Math.sqrt(Math.pow(c[0] - end[0], 2) + Math.pow(c[1] - end[1], 2))
 
@@ -343,7 +339,7 @@ var interpolateRect = function(start, end, tool, pathGraph, plotter) {
       [sXMax, sYMax])
   }
 
-  forEach(points, function(p, i) {
+  points.forEach(function(p, i) {
     var j = (i < (points.length - 1)) ? i + 1 : 0
     pathGraph.add({type: 'line', start: p, end: points[j]})
   })

--- a/lib/path-graph.js
+++ b/lib/path-graph.js
@@ -1,12 +1,22 @@
 // utilities to create a graph of path segments and traverse that graph
 'use strict'
 
-var forEachRight = require('lodash.foreachright')
 var fill = require('lodash.fill')
-var find = require('lodash.find')
-var map = require('lodash.map')
 
 var GAP = 0.00011
+
+var find = function(collection, condition) {
+  var element
+  var i
+
+  for (i = 0; i < collection.length; i++) {
+    element = collection[i]
+
+    if (condition(element)) {
+      return element
+    }
+  }
+}
 
 var distance = function(point, target) {
   return Math.sqrt(Math.pow(point[0] - target[0], 2) + Math.pow(point[1] - target[1], 2))
@@ -63,6 +73,10 @@ PathGraph.prototype.add = function(newSeg) {
     end = find(this._points, function(point) {
       return pointsEqual(point.position, newSeg.end, fillGaps)
     })
+
+    end = find(this._points, function(point) {
+      return pointsEqual(point.position, newSeg.end, fillGaps)
+    })
   }
 
   var startAndEndExist = (start && end)
@@ -107,7 +121,9 @@ PathGraph.prototype.add = function(newSeg) {
 
 PathGraph.prototype.traverse = function() {
   if (!this._optimize) {
-    return map(this._edges, 'segment')
+    return this._edges.map(function(edge) {
+      return edge.segment
+    })
   }
 
   var walked = fill(Array(this._edges.length), false)
@@ -143,7 +159,7 @@ PathGraph.prototype.traverse = function() {
         }
 
         // add non-walked adjacent nodes to the discovered stack
-        forEachRight(lastEnd.edges, function(seg) {
+        lastEnd.edges.reverse().forEach(function(seg) {
           if (!walked[seg]) {
             discovered.push(seg)
           }

--- a/lib/plotter.js
+++ b/lib/plotter.js
@@ -3,9 +3,6 @@
 
 var Transform = require('readable-stream').Transform
 var inherits = require('inherits')
-var has = require('lodash.has')
-var mapValues = require('lodash.mapvalues')
-var clone = require('lodash.clone')
 
 var PathGraph = require('./path-graph')
 var warning = require('./_warning')
@@ -135,16 +132,21 @@ Plotter.prototype._transform = function(chunk, encoding, done) {
     if (this.nota === 'I') {
       var _this = this
 
-      coord = mapValues(coord, function(value, key) {
+      coord = Object.keys(coord).reduce(function(result, key) {
+        var value = coord[key]
+
         if (key === 'x') {
-          return (_this._pos[0] + value)
+          result[key] = _this._pos[0] + value
         }
-        if (key === 'y') {
-          return (_this._pos[1] + value)
+        else if (key === 'y') {
+          result[key] = _this._pos[1] + value
+        }
+        else {
+          result[key] = value
         }
 
-        return value
-      })
+        return result
+      }, {})
     }
 
     if (op === 'last') {
@@ -212,7 +214,7 @@ Plotter.prototype._transform = function(chunk, encoding, done) {
       if (this._region) {
         this._warn('cannot change tool while region mode is on')
       }
-      else if (!has(this._tools, value)) {
+      else if (!this._tools[value]) {
         this._warn('tool ' + value + ' is not defined')
       }
       else if (!this._outTool){
@@ -276,7 +278,7 @@ Plotter.prototype._transform = function(chunk, encoding, done) {
       this.push({
         type: 'polarity',
         polarity: (levelValue === 'C') ? 'clear' : 'dark',
-        box: clone(this._box)
+        box: this._box.slice(0)
       })
     }
     else {
@@ -289,7 +291,11 @@ Plotter.prototype._transform = function(chunk, encoding, done) {
       }
       this._stepRep = offsets
 
-      this.push({type: 'repeat', offsets: clone(this._stepRep), box: clone(this._box)})
+      this.push({
+        type: 'repeat',
+        offsets: this._stepRep.slice(0),
+        box: this._box.slice(0)
+      })
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -48,19 +48,9 @@
   },
   "dependencies": {
     "inherits": "^2.0.1",
-    "lodash.clone": "^4.3.2",
     "lodash.fill": "^3.3.4",
-    "lodash.filter": "^4.3.0",
-    "lodash.find": "^4.3.0",
-    "lodash.foreach": "^4.2.0",
-    "lodash.foreachright": "^4.1.0",
-    "lodash.has": "^4.3.1",
     "lodash.isfinite": "^3.3.1",
     "lodash.isfunction": "^3.0.6",
-    "lodash.map": "^4.3.0",
-    "lodash.mapvalues": "^4.3.0",
-    "lodash.reduce": "^4.3.0",
-    "lodash.transform": "^4.3.0",
     "readable-stream": "^2.1.2"
   }
 }

--- a/test/gerber-plotter_test.js
+++ b/test/gerber-plotter_test.js
@@ -2,7 +2,6 @@
 'use strict'
 
 var expect = require('chai').expect
-var forEach = require('lodash.foreach')
 
 var plotter = require('../lib')
 var boundingBox = require('../lib/_box')
@@ -1670,7 +1669,7 @@ describe('gerber plotter', function() {
       p.write({type: 'tool', code: '11', tool: tool1})
       p.write({type: 'tool', code: '10', tool: tool0})
 
-      forEach(path, function(path) {
+      path.forEach(function(path) {
         p._path.add(path)
       })
     })


### PR DESCRIPTION
Similarly to mcous/gerber-parser#10, this PR removes a bunch of the lodash modules in favor of using native methods to reduce bundle size. Minified, optimized webpack bundle (`$ webpack lib/index.js ~/Desktop/gerber-plotter.bundle.js --optimize-minimize --optimize-occurrence-order --optimize-dedupe`) went from 137KB to 104KB.