### PR TITLE
Gap fill size should be configurable with options.plotAsOutline

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,14 +24,14 @@ var plotter = gerberPlotter(options)
 
 The available options are:
 
-key             | value        | default | description
-----------------|--------------|---------|---------------------------------------------------------
-`units`         | `mm` or `in` | N/A     | PCB units
-`backupUnits`   | `mm` or `in` | `in`    | Backup units in case units are missing
-`nota`          | `A` or `I`   | N/A     | Absolute or incremental coordinate notation
-`backupNota`    | `A` or `I`   | `A`     | Backup notation in case notation is missing
-`optimizePaths` | Boolean      | `false` | Optimize order of paths in strokes and regions
-`plotAsOutline` | Boolean      | `false` | Treat layer as an outline by combining all tools for paths
+key             | value          | default | description
+----------------|----------------|---------|------------------------------------------------
+`units`         | `mm` or `in`   | N/A     | PCB units
+`backupUnits`   | `mm` or `in`   | `in`    | Backup units in case units are missing
+`nota`          | `A` or `I`     | N/A     | Absolute or incremental coordinate notation
+`backupNota`    | `A` or `I`     | `A`     | Backup notation in case notation is missing
+`optimizePaths` | Boolean        | `false` | Optimize order of paths in strokes and regions
+`plotAsOutline` | Boolean/Number | `false` | Adjust paths to better represent an outline
 
 #### units and backup units options
 
@@ -51,14 +51,16 @@ Setting this option to `false` will speed up plotting at the expense of ensuring
 
 #### plot as outline option
 
-This option is off by default. When `plotAsOutline` is true, the plotter will take several actions:
+This option is off by default. When `plotAsOutline` is true or a number, the plotter will take several actions:
 
   * The `optimizePaths` option will be forced to true
   * All stroke tools will be merged into one tool (the first tool in the file used for a stroke)
   * The bounding box of the file will be determined by the center of the outline instead of the outside of the line
-  * Gaps smaller than about 0.00015 in/mm will be filled in
+  * Gaps between segments will be filled in
+    * If `plotAsOutline` is true, the maximum gap size will be 0.00011 in layer units
+    * If a number, that number will be used as the maximum gap size
 
-This option exists to take an image representing an outline layer and optimize it to get at the board information the layer represents. Sometimes, outline layers will (accidentally) use different tools for the same line or introduce small gaps in the outline. `plotAsOutline` will attempt to fix details like that.
+This option exists to take an image representing an outline layer and optimize it to get at the board information the layer represents. Sometimes, outline layers will (accidentally) use different tools for the same line or introduce small gaps in the outline. `plotAsOutline` will attempt to fix those details.
 
 ## public properties
 

--- a/lib/path-graph.js
+++ b/lib/path-graph.js
@@ -3,7 +3,7 @@
 
 var fill = require('lodash.fill')
 
-var GAP = 0.00011
+var MAX_GAP = 0.00011
 
 var find = function(collection, condition) {
   var element
@@ -27,7 +27,7 @@ var pointsEqual = function(point, target, fillGaps) {
     return ((point[0] === target[0]) && (point[1] === target[1]))
   }
 
-  return (distance(point, target) < GAP)
+  return (distance(point, target) < fillGaps)
 }
 
 var lineSegmentsEqual = function(segment, target) {
@@ -55,7 +55,9 @@ var PathGraph = function(optimize, fillGaps) {
   this._points = []
   this._edges = []
   this._optimize = optimize
-  this._fillGaps = fillGaps
+  this._fillGaps = (fillGaps === true)
+    ? MAX_GAP
+    : fillGaps
 
   this.length = 0
 }

--- a/test/gerber-plotter_test.js
+++ b/test/gerber-plotter_test.js
@@ -1858,10 +1858,16 @@ describe('gerber plotter', function() {
     })
 
     it('should fill gaps in paths if in outline mode', function() {
-      expect(outPlotter._path._fillGaps).to.be.true
+      expect(outPlotter._path._fillGaps).to.be.truthy
       outPlotter.write({type: 'op', op: 'int', coord: {x: 1, y: 3}})
       outPlotter._finishPath()
-      expect(outPlotter._path._fillGaps).to.be.true
+      expect(outPlotter._path._fillGaps).to.be.truthy
+    })
+
+    it('should be able to set a custom max gap size', function() {
+      outPlotter = plotter({plotAsOutline: 0.0011})
+
+      expect(outPlotter._path._fillGaps).to.equal(0.0011)
     })
   })
 

--- a/test/path-graph_test.js
+++ b/test/path-graph_test.js
@@ -173,4 +173,20 @@ describe('path graphs', function() {
       {type: 'line', start: [0, 1], end: [0, 0]}
     ])
   })
+
+  it('should be able to fill gaps with a specified gap distance', function() {
+    p = new PathGraph(true, 0.0011)
+
+    p.add({type: 'line', start: [0, 0], end: [1, 0]})
+    p.add({type: 'line', start: [1.001, 0], end: [1, 1]})
+    p.add({type: 'line', start: [1.001, 1], end: [0, 1]})
+    p.add({type: 'line', start: [0, 1.001], end: [0, 0]})
+
+    expect(p.traverse()).to.eql([
+      {type: 'line', start: [0, 0], end: [1, 0]},
+      {type: 'line', start: [1, 0], end: [1, 1]},
+      {type: 'line', start: [1, 1], end: [0, 1]},
+      {type: 'line', start: [0, 1], end: [0, 0]}
+    ])
+  })
 })


### PR DESCRIPTION
The outline layer of [8BitMixtape/NextLevelEdition](https://github.com/8BitMixtape/NextLevelEdition) has outline gaps that are several orders of magnitudes larger than the maximum gap size that the path optimizer can fill. However, bumping the max gap size up allows the outline to plot (relatively) correctly.

A maximum gap size of 0.011 is able to solve (with some visual artifacts at the gaps) tracespace/pcb-stackup#20. For reference, the default gap size is 0.00011 (units are whatever units the layer is in).

Setting `options.plotAsOutline` to `true` should use the default maximum gap size, and setting it to a number should use that number as the maximum gap size.